### PR TITLE
Broken navigation

### DIFF
--- a/responsiveslides.js
+++ b/responsiveslides.js
@@ -245,9 +245,9 @@
             nextIdx = idx + 1 < length ? index + 1 : 0;
 
           // Go to slide
-          slideTo($(this).is($prev) ? prevIdx : nextIdx);
+          slideTo($(this)[0] === $prev[0] ? prevIdx : nextIdx);
           if (settings.pager === true) {
-            selectTab($(this).is($prev) ? prevIdx : nextIdx);
+            selectTab($(this)[0] === $prev[0] ? prevIdx : nextIdx);
           }
 
           restartCycle();


### PR DESCRIPTION
Currently, the navigation will always cycle forward, even if the previous link was clicked.

This proposed change uses jQuery's [.is()](http://api.jquery.com/is/) filter. However it was only introduced in jQuery 1.6.

If you'd like to keep jQuery 1.4 as a dependency, you need to compare the raw DOM elements:

```
var index = $(this)[0] === $prev[0] ? prevIdx : nextIdx;
```
