### PR TITLE
Avoid negative tab indices when using the backwards button. Fixes bug with jquery 1.3.2

### DIFF
--- a/responsiveslides.js
+++ b/responsiveslides.js
@@ -343,7 +343,7 @@
 
             // Determine where to slide
             var idx = $slide.index($visibleClass),
-              prevIdx = idx - 1,
+              prevIdx = idx - 1 >= 0     ? index - 1 : length -1,
               nextIdx = idx + 1 < length ? index + 1 : 0;
 
             // Go to slide


### PR DESCRIPTION
This pull request fixes a bug with jquery 1.3.2. Since jquery 1.3.2. is no longer supported by ResponsiveSlides I dont know if you want to pull it. But the change is only one line and improves backwards compatability, so it may be worth it.

Thanks, Kob.
