### PR TITLE
Set "this" to target slide. Fixes #42.

### DIFF
--- a/responsiveslides.js
+++ b/responsiveslides.js
@@ -93,7 +93,7 @@
 
         // Fading animation
         slideTo = function (idx) {
-          settings.before();
+          settings.before.call($slide.eq(idx));
           // If CSS3 transitions are supported
           if (supportsTransitions) {
             $slide
@@ -104,7 +104,7 @@
               .css(visible);
             index = idx;
             setTimeout(function () {
-              settings.after();
+              settings.after.call($slide.eq(idx));
             }, fadeTime);
           // If not, use jQuery fallback
           } else {
@@ -121,7 +121,7 @@
                 $(this)
                   .addClass(visibleClass)
                   .css(visible);
-                settings.after();
+                settings.after.call($slide.eq(idx));
                 index = idx;
               });
           }


### PR DESCRIPTION
I need to know the target slide in before/after callbacks. This lets me use "this" from within my callbacks to operate on the target (incoming) slide.
