### PR TITLE
Stop CSS from being too greedy

### DIFF
--- a/responsiveslides.css
+++ b/responsiveslides.css
@@ -9,7 +9,7 @@
   margin: 0;
   }
 
-.rslides li {
+.rslides > li {
   -webkit-backface-visibility: hidden;
   position: absolute;
   display: none;
@@ -18,13 +18,13 @@
   top: 0;
   }
 
-.rslides li:first-child {
+.rslides > li:first-child {
   position: relative;
   display: block;
   float: left;
   }
 
-.rslides img {
+.rslides > img {
   display: block;
   height: auto;
   float: left;


### PR DESCRIPTION
responsiveslides.css is affecting list elements inside of slides (which, in my case, are divs full of various other content) when it shouldn't be. Here's a simple tweak to ensure it's only affecting elements which are direct children of the .rslides container.
