### PR TITLE
namespaceIdx added in settings so that it would be available in before/after callbacks by this.namespaceIdx

### DIFF
--- a/responsiveslides.js
+++ b/responsiveslides.js
@@ -35,6 +35,9 @@
 
       // Index for namespacing
       i++;
+      
+      // To make namespaceIdx available in before/after function
+      settings.namespaceIdx = settings.namespace + i;
 
       var $this = $(this),
 


### PR DESCRIPTION
The namespaceIdx should be available in before/after callbacks so that it would be easy to identify the slides in case someone's initializing multiple sliders on a page and wants to do something with the slides in before/after callbacks
